### PR TITLE
Time unit installments

### DIFF
--- a/contracts/utils/BytesUtils.sol
+++ b/contracts/utils/BytesUtils.sol
@@ -102,4 +102,39 @@ contract BytesUtils {
         }
         require(_data.length >= o, "Reading bytes out of bounds");
     }
+
+    function decode(
+        bytes _data,
+        uint256 _la,
+        uint256 _lb,
+        uint256 _lc,
+        uint256 _ld,
+        uint256 _le
+    ) internal pure returns (bytes32 _a, bytes32 _b, bytes32 _c, bytes32 _d, bytes32 _e) {
+        uint256 o;
+        assembly {
+            let s := add(_data, 32)
+            _a := mload(s)
+            let l := sub(32, _la)
+            if l { _a := div(_a, exp(2, mul(l, 8))) }
+            o := add(s, _la)
+            _b := mload(o)
+            l := sub(32, _lb)
+            if l { _b := div(_b, exp(2, mul(l, 8))) }
+            o := add(o, _lb)
+            _c := mload(o)
+            l := sub(32, _lc)
+            if l { _c := div(_c, exp(2, mul(l, 8))) }
+            o := add(o, _lc)
+            _d := mload(o)
+            l := sub(32, _ld)
+            if l { _d := div(_d, exp(2, mul(l, 8))) }
+            o := add(o, _ld)
+            _e := mload(o)
+            l := sub(32, _le)
+            if l { _e := div(_e, exp(2, mul(l, 8))) }
+            o := sub(o, s)
+        }
+        require(_data.length >= o, "Reading bytes out of bounds");
+    }
 }

--- a/test/BytesUtilsTest.sol
+++ b/test/BytesUtilsTest.sol
@@ -32,6 +32,17 @@ contract TestBytesUtils is BytesUtils {
     function pDecode(bytes data, uint256 a, uint256 b, uint256 c, uint256 d) public returns (bytes32,bytes32,bytes32,bytes32) {
         return decode(data, a, b, c, d);
     }
+
+    function pDecode(
+        bytes data,
+        uint256 a,
+        uint256 b,
+        uint256 c,
+        uint256 d,
+        uint256 e
+    ) public returns (bytes32,bytes32,bytes32,bytes32,bytes32) {
+        return decode(data, a, b, c, d, e);
+    }
 }
 
 // Proxy contract for testing throws
@@ -144,7 +155,7 @@ contract BytesUtilsTest {
 
     function testDecode() external {
         bytes32 test4 = keccak256("test4");
-        bytes memory data = abi.encodePacked(uint8(12), true, test4, address(this));
+        bytes memory data = abi.encodePacked(uint8(12), true, test4, address(this), uint256(0) - 1);
         (bytes32 a) = bytesUtils.pDecode(data, 1);
         Assert.equal(uint256(a), 12, "Decode 1 item");
         bytes32 b;
@@ -162,5 +173,12 @@ contract BytesUtilsTest {
         Assert.equal(b, bytes32(1), "Decode 4 items");
         Assert.equal(c, test4, "Decode 4 items");
         Assert.equal(address(d), address(this), "Decode 4 items");
+        bytes32 e;
+        (a, b, c, d, e) = bytesUtils.pDecode(data, 1, 1, 32, 20, 32);
+        Assert.equal(uint256(a), 12, "Decode 5 items");
+        Assert.equal(b, bytes32(1), "Decode 5 items");
+        Assert.equal(c, test4, "Decode 5 items");
+        Assert.equal(address(d), address(this), "Decode 5 items");
+        Assert.equal(uint256(e), uint256(0) - 1, "Decode 5 items");
     }
 }

--- a/test/TestInstallmentsModel.js
+++ b/test/TestInstallmentsModel.js
@@ -22,7 +22,8 @@ contract('Installments model', function(accounts) {
       110,
       Helper.toInterestRate(240),
       10,
-      30 * 86400
+      30 * 86400,
+      1
     );
     await model.create(id, data);
     await Helper.assertThrow(model.create(id, data));
@@ -34,7 +35,8 @@ contract('Installments model', function(accounts) {
       110,
       Helper.toInterestRate(240),
       10,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     assert.isTrue(await model.validate(data), "Registry data should be valid");
@@ -59,7 +61,8 @@ contract('Installments model', function(accounts) {
       110,
       Helper.toInterestRate(240),
       10,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -75,7 +78,8 @@ contract('Installments model', function(accounts) {
       web3.toWei(110),
       Helper.toInterestRate(20),
       1,
-      360 * 86400
+      360 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -97,7 +101,8 @@ contract('Installments model', function(accounts) {
       300,
       Helper.toInterestRate(240),
       3,
-      30 * 86400
+      30 * 86400,
+      86400
     );
 
     await model.create(id, data);
@@ -136,7 +141,8 @@ contract('Installments model', function(accounts) {
       110,
       Helper.toInterestRate(240),
       10,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -160,7 +166,8 @@ contract('Installments model', function(accounts) {
       110,
       Helper.toInterestRate(240),
       10,
-      30 * 86400
+      30 * 86400,
+      86400
     );
 
     await model.create(id, data);
@@ -198,7 +205,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      86400
     );
 
     await model.create(id, data);
@@ -268,7 +276,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -338,7 +347,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      86400
     );
 
     await model.create(id, data);
@@ -407,7 +417,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      86400
     );
 
     await model.create(id, data);
@@ -462,7 +473,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -520,7 +532,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -580,7 +593,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -616,7 +630,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);
@@ -652,7 +667,8 @@ contract('Installments model', function(accounts) {
       99963,
       Helper.toInterestRate(35 * 1.5),
       12,
-      30 * 86400
+      30 * 86400,
+      1
     );
 
     await model.create(id, data);


### PR DESCRIPTION
Depends on #42 

Adds a configurable minimum time unit to the InstallmentsModel, any delta time lower is ignored. 

The window is defined in seconds, and it should be lower than the installments duration.

Notice: a higher time window will reduce the real interest rate precision.