### PR TITLE
emit Approved(futureDebt) event when requestLoan

### DIFF
--- a/contracts/diaspore/LoanManager.sol
+++ b/contracts/diaspore/LoanManager.sol
@@ -103,6 +103,7 @@ contract LoanManager {
         uint64 pos;
         if (approved) {
             pos = uint64(directory.push(futureDebt) - 1);
+            emit Approved(futureDebt);
         }
 
         requests[futureDebt] = Request({


### PR DESCRIPTION
This event should be emit on requestLoan when the msg.sender its the same of borrower