### PR TITLE
Make the debt id unique by instance

### DIFF
--- a/contracts/diaspore/DebtEngine.sol
+++ b/contracts/diaspore/DebtEngine.sol
@@ -119,6 +119,7 @@ contract DebtEngine is ERC721Base {
         id = keccak256(
             abi.encodePacked(
                 uint8(1),
+                address(this),
                 _owner,
                 nonce
             )
@@ -154,6 +155,7 @@ contract DebtEngine is ERC721Base {
         id = keccak256(
             abi.encodePacked(
                 uint8(2),
+                address(this),
                 msg.sender,
                 _model,
                 _oracle,
@@ -193,6 +195,7 @@ contract DebtEngine is ERC721Base {
         id = keccak256(
             abi.encodePacked(
                 uint8(3),
+                address(this),
                 msg.sender,
                 _salt
             )
@@ -220,10 +223,11 @@ contract DebtEngine is ERC721Base {
     function buildId(
         address _creator,
         uint256 _nonce
-    ) external pure returns (bytes32) {
+    ) external view returns (bytes32) {
         return keccak256(
             abi.encodePacked(
                 uint8(1),
+                address(this),
                 _creator,
                 _nonce
             )
@@ -237,10 +241,11 @@ contract DebtEngine is ERC721Base {
         bytes8 _currency,
         uint256 _salt,
         bytes _data
-    ) external pure returns (bytes32) {
+    ) external view returns (bytes32) {
         return keccak256(
             abi.encodePacked(
                 uint8(2),
+                address(this),
                 _creator,
                 _model,
                 _oracle,
@@ -254,10 +259,11 @@ contract DebtEngine is ERC721Base {
     function buildId3(
         address _creator,
         uint256 _salt
-    ) external pure returns (bytes32) {
+    ) external view returns (bytes32) {
         return keccak256(
             abi.encodePacked(
                 uint8(3),
+                address(this),
                 _creator,
                 _salt
             )

--- a/test/diaspore/TestDebtEngine.js
+++ b/test/diaspore/TestDebtEngine.js
@@ -155,6 +155,97 @@ contract('Test DebtEngine Diaspore', function(accounts) {
         assert.equal(await testModel.getPaid(id), 3000);
     });
 
+    it("Differents debt engine should give differents ids, create", async function(){
+        const engine1 = await DebtEngine.new(rcn.address);
+        const engine2 = await DebtEngine.new(rcn.address);
+
+        await testModel.setEngine(engine1.address);
+
+        const id1 = await getId(engine1.create(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(engine2.address);
+
+        const id2 = await getId(engine2.create(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(debtEngine.address);
+
+        assert.notEqual(id1, id2);
+    });
+
+    it("Differents debt engine should give differents ids, create2", async function(){
+        const engine1 = await DebtEngine.new(rcn.address);
+        const engine2 = await DebtEngine.new(rcn.address);
+
+        await testModel.setEngine(engine1.address);
+
+        const id1 = await getId(engine1.create2(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            768484844,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(engine2.address);
+
+        const id2 = await getId(engine2.create2(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            768484844,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(debtEngine.address);
+
+        assert.notEqual(id1, id2);
+    });
+
+    it("Differents debt engine should give differents ids, create3", async function(){
+        const engine1 = await DebtEngine.new(rcn.address);
+        const engine2 = await DebtEngine.new(rcn.address);
+
+        await testModel.setEngine(engine1.address);
+
+        const id1 = await getId(engine1.create3(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            768484844,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(engine2.address);
+
+        const id2 = await getId(engine2.create3(
+            testModel.address,
+            accounts[0],
+            0x0,
+            0x0,
+            768484844,
+            await testModel.encodeData(3000, (await Helper.getBlockTime()) + 2000)
+        ));
+
+        await testModel.setEngine(debtEngine.address);
+
+        assert.notEqual(id1, id2);
+    });
+
     it("Should withdraw funds from payment", async function() {
         const id = await getId(debtEngine.create(
             testModel.address,
@@ -338,23 +429,23 @@ contract('Test DebtEngine Diaspore', function(accounts) {
 
     it("Should create different ids create2 and create3", async function() {
         const expireTime = (await Helper.getBlockTime()) + 2000;
-        const id1 = await debtEngine.create2(
+        const id1 = await getId(debtEngine.create2(
             testModel.address,
             accounts[0],
             0x0,
             0x0,
             89999,
             await testModel.encodeData(1001, expireTime)
-        );
+        ));
 
-        const id2 = await debtEngine.create3(
+        const id2 = await getId(debtEngine.create3(
             testModel.address,
             accounts[0],
             0x0,
             0x0,
             89999,
             await testModel.encodeData(1001, expireTime)
-        );
+        ));
 
         assert.notEqual(id1, id2);
     });


### PR DESCRIPTION
- Created test case, with create, create2 and create3
- Add debt engine address to keccak256 of debt id
- Fix Should create different ids create2 and create3 test