### PR TITLE
Add RegisterApproveRequest method to LoanManager

### DIFF
--- a/contracts/diaspore/interfaces/LoanApprover.sol
+++ b/contracts/diaspore/interfaces/LoanApprover.sol
@@ -32,14 +32,14 @@ contract LoanApprover is IERC165 {
         Request the approve of a loan being settled, the contract can be called as borrower or creator.
         To approve the request the contract should return:
 
-        _signature XOR 0xdfcb15a077f54a681c23131eacdfd6e12b5e099685b492d382c3fd8bfc1e9a2a
+        _id XOR 0xdfcb15a077f54a681c23131eacdfd6e12b5e099685b492d382c3fd8bfc1e9a2a
 
         @param _requestData All the parameters of the loan request
         @param _loanData Data to feed to the Model
         @param _isBorrower True if this contract is the borrower, False if the contract is the creator
-        @param _signature loanManager.requestSignature(_requestDatam _loanData)
+        @param _id loanManager.requestSignature(_requestDatam _loanData)
 
-        @return _signature XOR keccak256("approve-loan-request"), if the approve is accepted
+        @return _id XOR keccak256("approve-loan-request"), if the approve is accepted
     */
-    function settleApproveRequest(bytes _requestData, bytes _loanData, bool _isBorrower, uint256 _signature) external returns (bytes32);
+    function settleApproveRequest(bytes _requestData, bytes _loanData, bool _isBorrower, uint256 _id) external returns (bytes32);
 }

--- a/contracts/diaspore/utils/test/TestLoanApprover.sol
+++ b/contracts/diaspore/utils/test/TestLoanApprover.sol
@@ -1,0 +1,59 @@
+pragma solidity ^0.4.24;
+
+import "./../../interfaces/LoanApprover.sol";
+import "./../../../utils/ERC165.sol";
+
+contract TestLoanApprover is ERC165, LoanApprover {
+    enum ErrorBehavior {
+        Revert,
+        ReturnFalse,
+        WrongReturn
+    }
+
+    bytes32 public expectedApprove;
+
+    ErrorBehavior public errorBehavior;
+
+    constructor() public {
+        _registerInterface(0x76ba6009);
+        _registerInterface(0xcd40239e);
+        _registerInterface(0xbbfa4397);
+    }
+
+    function setExpectedApprove(
+        bytes32 _expected
+    ) external {
+        expectedApprove = _expected;
+    }
+
+    function setErrorBehavior(
+        ErrorBehavior _code
+    ) external {
+        errorBehavior = _code;
+    }
+
+    function approveRequest(
+        bytes32 _futureDebt
+    ) external returns (bytes32) {
+        if (_futureDebt != expectedApprove) {
+            if (errorBehavior == ErrorBehavior.Revert) {
+                revert("Loan rejected");
+            } else if (errorBehavior == ErrorBehavior.WrongReturn) {
+                return _futureDebt;
+            } else {
+                return;
+            }
+        }
+
+        return _futureDebt ^ 0xdfcb15a077f54a681c23131eacdfd6e12b5e099685b492d382c3fd8bfc1e9a2a;
+    }
+
+    function settleApproveRequest(
+        bytes _requestData,
+        bytes _loanData,
+        bool _isBorrower,
+        uint256 _id
+    ) external returns (bytes32) {
+
+    }
+}

--- a/test/diaspore/TestLoanManager.js
+++ b/test/diaspore/TestLoanManager.js
@@ -2,6 +2,7 @@ const LoanManager = artifacts.require('./diaspore/LoanManager.sol');
 const TestModel = artifacts.require('./diaspore/utils/test/TestModel.sol');
 const DebtEngine = artifacts.require('./diaspore/DebtEngine.sol');
 const TestToken = artifacts.require('./utils/test/TestToken.sol');
+const TestLoanApprover = artifacts.require('./diaspore/utils/test/TestLoanApprover.sol');
 
 const Helper = require('../Helper.js');
 const Web3Utils = require('web3-utils');
@@ -17,6 +18,7 @@ contract('Test LoanManager Diaspore', function (accounts) {
     let debtEngine;
     let loanManager;
     let model;
+    let loanApprover;
 
     async function getId (promise) {
         const receipt = await promise;
@@ -96,6 +98,7 @@ contract('Test LoanManager Diaspore', function (accounts) {
         loanManager = await LoanManager.new(debtEngine.address);
         model = await TestModel.new();
         await model.setEngine(debtEngine.address);
+        loanApprover = await TestLoanApprover.new();
     });
 
     it('Should create a loan using requestLoan', async function () {
@@ -209,5 +212,347 @@ contract('Test LoanManager Diaspore', function (accounts) {
 
     it('Should fail internal salt if id does not exist', async function () {
         await Helper.tryCatchRevert(loanManager.internalSalt(0x2), 'Request does not exist');
+    });
+
+    it('Should register approve using the borrower signature', async function () {
+        const creator = accounts[1];
+        const borrower = accounts[2];
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 4;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        // Sign loan id
+        const signature = await web3.eth.sign(borrower, id);
+
+        const receipt = await loanManager.registerApproveRequest(id, signature, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.equal(event.args._id, id);
+
+        // Should add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength.toNumber() + 1);
+        (await loanManager.directory(dlength)).should.be.bignumber.equal(id);
+    });
+
+    it('Should ignore approve with wrong borrower signature', async function () {
+        const creator = accounts[1];
+        const borrower = accounts[2];
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 5;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        // Sign loan id
+        const signature = await web3.eth.sign(borrower, Helper.toBytes32(accounts[3]));
+
+        const receipt = await loanManager.registerApproveRequest(id, signature, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), false);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.notOk(event);
+
+        // Should not add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength);
+    });
+
+    it('Should ignore a second approve using registerApprove', async function () {
+        const creator = accounts[1];
+        const borrower = accounts[2];
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 6;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        // Sign loan id
+        const signature = await web3.eth.sign(borrower, id);
+
+        const receipt = await loanManager.registerApproveRequest(id, signature, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.equal(event.args._id, id);
+
+        const receipt2 = await loanManager.registerApproveRequest(id, signature, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event2 = receipt2.logs.find(l => l.event === 'Approved');
+        assert.notOk(event2);
+
+        // Should add the entry to the directory once
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength.toNumber() + 1);
+        (await loanManager.directory(dlength)).should.be.bignumber.equal(id);
+    });
+
+    it('Should register approve using the borrower callback', async function () {
+        const creator = accounts[1];
+        const borrower = loanApprover.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 4;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        // Set expected id
+        await loanApprover.setExpectedApprove(id);
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.equal(event.args._id, id);
+
+        // Should add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength.toNumber() + 1);
+        (await loanManager.directory(dlength)).should.be.bignumber.equal(id);
+    });
+
+    it('Should ignore approve if borrower callback reverts', async function () {
+        const creator = accounts[1];
+        const borrower = loanApprover.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 5;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        await loanApprover.setErrorBehavior(0);
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), false);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.notOk(event);
+
+        // Should not add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength);
+    });
+
+    it('Should ignore approve if borrower callback returns false', async function () {
+        const creator = accounts[1];
+        const borrower = loanApprover.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 6;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        await loanApprover.setErrorBehavior(1);
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), false);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.notOk(event);
+
+        // Should not add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength);
+    });
+
+    it('Should ignore approve if borrower callback returns wrong value', async function () {
+        const creator = accounts[1];
+        const borrower = loanApprover.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 7;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        await loanApprover.setErrorBehavior(2);
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), false);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.notOk(event);
+
+        // Should not add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength);
+    });
+
+    it('Should ignore a second approve using registerApprove and callbacks', async function () {
+        const creator = accounts[1];
+        const borrower = loanApprover.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 6;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        await loanApprover.setExpectedApprove(id);
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.equal(event.args._id, id);
+
+        const receipt2 = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), true);
+
+        const event2 = receipt2.logs.find(l => l.event === 'Approved');
+        assert.notOk(event2);
+
+        // Should add the entry to the directory once
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength.toNumber() + 1);
+        (await loanManager.directory(dlength)).should.be.bignumber.equal(id);
+    });
+
+    it('Should not call callback if the borrower contract does not implements loan approver', async function () {
+        const creator = accounts[1];
+        const borrower = debtEngine.address;
+
+        const expiration = (await Helper.getBlockTime()) + 1000;
+
+        const salt = 7;
+        const amount = 1000;
+
+        const loanData = await model.encodeData(amount, expiration);
+
+        const id = await getId(loanManager.requestLoan(
+            amount,           // Amount
+            model.address,    // Model
+            Helper.address0x, // Oracle
+            borrower,         // Borrower
+            salt,             // salt
+            expiration,       // Expiration
+            loanData,         // Loan data
+            { from: creator } // Creator
+        ));
+
+        const dlength = await loanManager.getDirectoryLength();
+
+        const receipt = await loanManager.registerApproveRequest(id, 0x0, { from: accounts[2] });
+        assert.equal(await loanManager.isApproved(id), false);
+
+        const event = receipt.logs.find(l => l.event === 'Approved');
+        assert.notOk(event);
+
+        // Should not add the entry to the directory
+        (await loanManager.getDirectoryLength()).should.be.bignumber.equal(dlength);
     });
 });


### PR DESCRIPTION
- Created test cases
- Created method register approve using signature
- If borrower is a contract, use approve callback
- Created TestLoanApprover util