### PR TITLE
Only transfer and check cosigner cost when the cost is not equal to 0

### DIFF
--- a/contracts/diaspore/LoanManager.sol
+++ b/contracts/diaspore/LoanManager.sol
@@ -381,8 +381,10 @@ contract LoanManager is BytesUtils {
         require(request.expiration > now, "Request is expired");
         require(request.cosigner == address(uint256(msg.sender) + 2), "Cosigner not valid");
         request.cosigner = msg.sender;
-        require(request.salt >= _cost, "Cosigner cost exceeded");
-        require(token.transferFrom(debtEngine.ownerOf(_id), msg.sender, _cost), "Error paying cosigner");
+        if (_cost != 0){
+            require(request.salt >= _cost, "Cosigner cost exceeded");
+            require(token.transferFrom(debtEngine.ownerOf(_id), msg.sender, _cost), "Error paying cosigner");
+        }
         emit Cosigned(bytes32(_id), msg.sender, _cost);
         return true;
     }


### PR DESCRIPTION
This change can save gas if the cosigner cost its 0