### PR TITLE
[RCN1-O17]-Change assembly call to high level call

### DIFF
--- a/contracts/commons/ERC721Base.sol
+++ b/contracts/commons/ERC721Base.sol
@@ -436,11 +436,9 @@ contract ERC721Base is ERC165 {
 
         if (_doCheck && _to.isContract()) {
             // Call dest contract
-            bool success;
-            bytes4 result;
             // Perform check with the new safe call
             // onERC721Received(address,address,uint256,bytes)
-            (success, result) = _noThrowCall(
+            (bool success, bytes4 result) = _noThrowCall(
                 _to,
                 abi.encodeWithSelector(
                     ERC721_RECEIVED,

--- a/contracts/commons/ERC721Base.sol
+++ b/contracts/commons/ERC721Base.sol
@@ -489,10 +489,10 @@ contract ERC721Base is ERC165 {
         address _contract,
         bytes memory _data
     ) internal returns (bool success, bytes4 result) {
-        bytes memory returndata;
-        (success, returndata) = _contract.call(_data);
+        bytes memory returnData;
+        (success, returnData) = _contract.call(_data);
 
-        if (returndata.length > 0)
-            result = abi.decode(returndata, (bytes4));
+        if (returnData.length > 0)
+            result = abi.decode(returnData, (bytes4));
     }
 }

--- a/contracts/commons/ERC721Base.sol
+++ b/contracts/commons/ERC721Base.sol
@@ -436,8 +436,8 @@ contract ERC721Base is ERC165 {
 
         if (_doCheck && _to.isContract()) {
             // Call dest contract
-            uint256 success;
-            bytes32 result;
+            bool success;
+            bytes4 result;
             // Perform check with the new safe call
             // onERC721Received(address,address,uint256,bytes)
             (success, result) = _noThrowCall(
@@ -451,7 +451,7 @@ contract ERC721Base is ERC165 {
                 )
             );
 
-            if (success != 1 || result != ERC721_RECEIVED) {
+            if (!success || result != ERC721_RECEIVED) {
                 // Try legacy safe call
                 // onERC721Received(address,uint256,bytes)
                 (success, result) = _noThrowCall(
@@ -465,7 +465,7 @@ contract ERC721Base is ERC165 {
                 );
 
                 require(
-                    success == 1 && result == ERC721_RECEIVED_LEGACY,
+                    success && result == ERC721_RECEIVED_LEGACY,
                     "Contract rejected the token"
                 );
             }
@@ -478,24 +478,21 @@ contract ERC721Base is ERC165 {
     // Utilities
     //
 
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract),
+     * relaxing the requirement on the return value
+     * @param _contract The contract that receives the ERC721
+     * @param _data The call data
+     * @return True if the call not reverts and the result of the call
+     */
     function _noThrowCall(
         address _contract,
         bytes memory _data
-    ) internal returns (uint256 success, bytes32 result) {
-        assembly {
-            let x := mload(0x40)
+    ) internal returns (bool success, bytes4 result) {
+        bytes memory returndata;
+        (success, returndata) = _contract.call(_data);
 
-            success := call(
-                            gas,                  // Send all gas
-                            _contract,            // To addr
-                            0,                    // Send ETH
-                            add(0x20, _data),     // Input is data past the first 32 bytes
-                            mload(_data),         // Input size is the lenght of data
-                            x,                    // Store the ouput on x
-                            0x20                  // Output is a single bytes32, has 32 bytes
-                        )
-
-            result := mload(x)
-        }
+        if (returndata.length > 0)
+            result = abi.decode(returndata, (bytes4));
     }
 }

--- a/contracts/core/diaspore/DebtEngine.sol
+++ b/contracts/core/diaspore/DebtEngine.sol
@@ -488,7 +488,7 @@ contract DebtEngine is ERC721Base, Ownable {
     ) internal returns (uint256) {
         require(_model != Model(0), "Debt does not exist");
 
-        (uint256 success, bytes32 paid) = _safeGasCall(
+        (bool success, bytes32 paid) = _safeGasCall(
             address(_model),
             abi.encodeWithSelector(
                 _model.addPaid.selector,
@@ -497,7 +497,7 @@ contract DebtEngine is ERC721Base, Ownable {
             )
         );
 
-        if (success == 1) {
+        if (success) {
             if (debts[_id].error) {
                 emit ErrorRecover({
                     _id: _id,
@@ -570,7 +570,7 @@ contract DebtEngine is ERC721Base, Ownable {
         Debt storage debt = debts[_id];
         require(debt.model != Model(0), "Debt does not exist");
 
-        (uint256 success, bytes32 result) = _safeGasCall(
+        (bool success, bytes32 result) = _safeGasCall(
             address(debt.model),
             abi.encodeWithSelector(
                 debt.model.run.selector,
@@ -578,7 +578,7 @@ contract DebtEngine is ERC721Base, Ownable {
             )
         );
 
-        if (success == 1) {
+        if (success) {
             if (debt.error) {
                 emit ErrorRecover({
                     _id: _id,
@@ -696,25 +696,23 @@ contract DebtEngine is ERC721Base, Ownable {
         }
     }
 
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract),
+     * relaxing the requirement on the return value
+     * @param _contract The contract that receives the call
+     * @param _data The call data
+     * @return True if the call not reverts and the result of the call
+     */
     function _safeGasCall(
         address _contract,
         bytes memory _data
-    ) internal returns (uint256 success, bytes32 result) {
+    ) internal returns (bool success, bytes32 result) {
+        bytes memory returnData;
         uint256 _gas = (block.gaslimit * 80) / 100;
-        _gas = gasleft() < _gas ? gasleft() : _gas;
-        assembly {
-            let x := mload(0x40)
-            success := call(
-                            _gas,                 // Send almost all gas
-                            _contract,            // To addr
-                            0,                    // Send ETH
-                            add(0x20, _data),     // Input is data past the first 32 bytes
-                            mload(_data),         // Input size is the lenght of data
-                            x,                    // Store the ouput on x
-                            0x20                  // Output is a single bytes32, has 32 bytes
-                        )
 
-            result := mload(x)
-        }
+        (success, returnData) = _contract.call.gas(gasleft() < _gas ? gasleft() : _gas)(_data);
+
+        if (returnData.length > 0)
+            result = abi.decode(returnData, (bytes32));
     }
 }

--- a/contracts/core/diaspore/LoanManager.sol
+++ b/contracts/core/diaspore/LoanManager.sol
@@ -250,7 +250,7 @@ contract LoanManager is BytesUtils {
     ) internal returns (bool approved) {
         // bytes32 expected = _id XOR keccak256("approve-loan-request");
         bytes32 expected = _id ^ 0xdfcb15a077f54a681c23131eacdfd6e12b5e099685b492d382c3fd8bfc1e9a2a;
-        (uint256 success, bytes32 result) = _safeCall(
+        (bool success, bytes32 result) = _safeCall(
             _borrower,
             abi.encodeWithSelector(
                 0x76ba6009,
@@ -258,13 +258,13 @@ contract LoanManager is BytesUtils {
             )
         );
 
-        approved = success == 1 && result == expected;
+        approved = success && result == expected;
 
         // Emit events if approve was rejected or failed
         if (approved) {
             emit ApprovedByCallback(_id);
         } else {
-            if (success == 0) {
+            if (!success) {
                 emit ApprovedError(_id, result);
             } else {
                 emit ApprovedRejected(_id, result);
@@ -748,23 +748,21 @@ contract LoanManager is BytesUtils {
         return tokens.mult(_amount) / equivalent;
     }
 
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract),
+     * relaxing the requirement on the return value
+     * @param _contract The borrower contract that receives the approveRequest(bytes32) call
+     * @param _data The call data
+     * @return True if the call not reverts and the result of the call
+     */
     function _safeCall(
         address _contract,
         bytes memory _data
-    ) internal returns (uint256 success, bytes32 result) {
-        assembly {
-            let x := mload(0x40)
-            success := call(
-                            gas,                 // Send almost all gas
-                            _contract,            // To addr
-                            0,                    // Send ETH
-                            add(0x20, _data),     // Input is data past the first 32 bytes
-                            mload(_data),         // Input size is the lenght of data
-                            x,                    // Store the ouput on x
-                            0x20                  // Output is a single bytes32, has 32 bytes
-                        )
+    ) internal returns (bool success, bytes32 result) {
+        bytes memory returnData;
+        (success, returnData) = _contract.call(_data);
 
-            result := mload(x)
-        }
+        if (returnData.length > 0)
+            result = abi.decode(returnData, (bytes32));
     }
 }


### PR DESCRIPTION
I cant change the DebtEngine#_safeGasStaticCall function, because its a view function 
This can be a implemented without inline asm in Solidity 0.5.10
See: [https://github.com/ripio/rcn-network/pull/201](https://github.com/ripio/rcn-network/pull/201)